### PR TITLE
Add some explanation to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Discussion: UnixFS Specification
+
+This repo is used to discuss and draft a specification for the next version of UnixFS (the DAG node format used to represent *files and directories* on the IPFS network). You can find and participate in discussion about desired features in [the issues](https://github.com/ipfs/ipld-unixfs/issues) and an [initial specification draft in PR #2](https://github.com/ipfs/ipld-unixfs/pull/2).
+
+When the specification draft is complete, it will be moved to the `ipfs/specs` repo at https://github.com/ipfs/specs/tree/master/unixfs and this repo will likely be re-dedicated to building the **Go** implementation of UnixFS.


### PR DESCRIPTION
When new folks are pointed to this repo, it appears totally empty and can be pretty confusing (see [this exchange](https://github.com/ipfs/go-ipfs/issues/612#issuecomment-383327501), for example), so I’ve drafted this simple README to help explain what’s going on here. Based off a conversation with @whyrusleeping and @lanzafame on IRC and Slack.

Alternatively, @whyrusleeping noted this all might belong in `ipfs/specs`. If someone wants to just port everything over now, I’ll change the text here to say it’s a placeholder for the Go implementation. Otherwise, this will really help folks understand the repo until that gets sorted out.