### PR TITLE
[DRAFT] File data representation.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -14,10 +14,30 @@ The `type` field is either `file` or `dir`.
 A file object has the following fields.
 
   - `type`: String with value of `'file'`.
-  - `data`: TODO: Define structure for file content data.
+  - `data`: Array of `file-data`.
   - `size`: Integer. Cumulative size of `data`.
 
 The `type` field must be set to `file`.
+
+### `file-data`
+
+File data is an Array. Each element is an Array with only 2 elements (Tuple).
+
+  - 0: Array. Tuple containing two integers, the `start` and `end` offsets of the content.
+    - 0: Integer: start offset.
+    - 1: Integer: end offset.
+  - 1: Link. Either a `raw` link or a link to another node formatted as `file-data`.
+
+```javascript
+[
+  [ [0, 1024], Link ],
+  [ [1025, 1089], Link ]
+]
+```
+
+Implementations are encouraged to use nested `file-data` array nodes through links for files
+with many chunks in order to limit the size of the serialized node. No strict boundary is
+set but it is typical to try and limit node size to less than one megabyte.
 
 ## IPLD `dir`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -23,15 +23,15 @@ The `type` field must be set to `file`.
 
 File data is an Array. Each element is an Array with only 2 elements (Tuple).
 
-  - 0: Array. Tuple containing two integers, the `start` and `end` offsets of the content.
+  - 0: Array. Tuple containing two integers, the `start` and `length` offsets of the content.
     - 0: Integer: start offset.
-    - 1: Integer: end offset.
+    - 1: Integer: length of part(s).
   - 1: Link. Either a `raw` link or a link to another node formatted as `file-data`.
 
 ```javascript
 [
   [ [0, 1024], Link ],
-  [ [1025, 1089], Link ]
+  [ [1025, 1002], Link ]
 ]
 ```
 


### PR DESCRIPTION
Here's a new take on the file data representation that attempts to solve many of the previous discussions.

* [Don't over load `data` field for special file types](https://github.com/ipfs/unixfs-v2/pull/2#discussion_r148713182).
* [Support data chunking definitions across multiple nodes through linking nested arrays in order to limit total node size](https://github.com/ipfs/unixfs-v2/pull/2/files#r198677670).
* [More easily support seeking in files](https://github.com/ipfs/unixfs-v2/pull/2/files#r198984820).

This is a pretty compact structure but it's quite simple and makes seeking into file ranges rather trivial.