### PR TITLE
Propose symlinks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -31,3 +31,19 @@ The value of the map is another CBOR map with the following standard fields:
   - `size`: Integer. Cumulative size of all directories and files in `data`.
 
 The `type` field set to `dir`.
+
+## IPLD `symlink`
+
+A symlink object conceptually stores a path to another file.
+
+Symlink content is really just a string, and could be any string, but it is
+normally expected to be a file.  It may be a relative or absolute path; and
+there is no guarantee that it is a clean or normalized path.  There is no
+guarantee that the path that a symlink points to will exist.
+
+A symlink object has the following fields:
+
+  - `type`: String with the value of `'sym'`.
+  - `target`: A string which is the target path of the symlink.
+
+The `type` field must be set to `sym`.


### PR DESCRIPTION
UnixfsV2 should have a way to encode symlinks.

Symlinks are a very commonly used and critical part of most unixy filesystems.

Symlinks are conceptually simple: at heart, they're just a string.  Kernels consider them thusly: readlink yields a string, and setting symlinks also is simply a string.  The content of the string is never really validated in advance, only evaluated when actually dereferenced: so we can do the same, and treat it as an opaque string.

Permissions of symlinks is not yet mentioned in this text; it should probably later be updated to use whatever is our choice for files and dirs (issue #14 discusses).