### PR TITLE
fix: removing all node/block specific language

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -50,9 +50,9 @@ A directory object represents a directory and has the following paths.
 
   - `type`: String with value of `'dir'`.
   - `data`: 
-    - Object with keys as file/directory names that are string encoded in UTF-8.
+    - Object (or `hamt`) with keys as file/directory names that are string encoded in UTF-8.
     - Values must be `file` or `dir` nodes.
-    - Link *may* resolve to a `hamt` root node.
+    - 
   - `size`: Integer. Cumulative size of all directories and files in `data`.
 
 The `type` path must be set to `dir`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,23 +1,28 @@
-# Draft IPLD Unixfs Spec
+# [Draft] IPLD UnixFS Spec
 
 ## Basic Structure
 
 A Unixfs is either a file or a directory.
 
-The top level IPLD object has at least two fields: `type` and `data`
+This specification uses the term "path(s)" to refer to specific key/value 
+pairs. Every path could be either an in-line value or a Link. This means 
+that a single UnixFS tree could be entirely inlined into a single Block or 
+could be many Blocks connected by CID Links.
+
+A top level IPLD object has at least two paths: `type` and `data`
 and maybe a few other such as a version string or a set of flags.
 
-The `type` field is either `file` or `dir`.
+The `type` path's value is either `file` or `dir`.
 
 ## IPLD `file`
 
-A file object has the following fields.
+A file object has the following paths.
 
   - `type`: String with value of `'file'`.
   - `data`: Array of `file-data`.
   - `size`: Integer. Cumulative size of `data`.
 
-The `type` field must be set to `file`.
+The `type` path must be set to `file`.
 
 ### `file-data`
 
@@ -26,7 +31,7 @@ File data is an Array. Each element is an Array with only 2 elements (Tuple).
   - 0: Array. Tuple containing two integers, the `start` and `length` offsets of the content.
     - 0: Integer: start offset.
     - 1: Integer: length of part(s).
-  - 1: Link. Either a `raw` link or a link to another node formatted as `file-data`.
+  - 1: Binary or `file-data`. Value can be either the binary data or additional nested `file-data` structures.
 
 ```javascript
 [
@@ -41,21 +46,16 @@ set but it is typical to try and limit node size to less than one megabyte.
 
 ## IPLD `dir`
 
-A directory object represents a directory.
-
-The key of the map is a filename and is a CBOR text string encoded in UTF-8.
-The value of the map is another CBOR map with the following standard fields:
+A directory object represents a directory and has the following paths.
 
   - `type`: String with value of `'dir'`.
-  - `data`: Object or Link. 
-    - `data` as Object: values must be links to `file` or `dir` nodes.
-    - `data` as Link: Link must resolve to a `hamt` root node.
+  - `data`: 
+    - Object with keys as file/directory names that are string encoded in UTF-8.
+    - Values must be links to `file` or `dir` nodes.
+    - Link *may* resolve to a `hamt` root node.
   - `size`: Integer. Cumulative size of all directories and files in `data`.
 
-The `type` field set to `dir`.
+The `type` path must be set to `dir`.
 
-The `data` field can be either an Object or a Link. When representing a directory structure with an object
-the keys are the directory names and the values must be links to either `file` or `dir` nodes. When 
-the keyspace is too large for a single node `data` should be a link to `hamt` node.
-
-`hamt` has not yet been specified but will follow the implementation [here](https://github.com/ipfs/go-hamt-ipld).
+When the keyspace is too large for a single node `data` should be a link to `hamt` node. `hamt` has 
+not yet been specified but will follow the implementation [here](https://github.com/ipfs/go-hamt-ipld).

--- a/SPEC.md
+++ b/SPEC.md
@@ -51,7 +51,7 @@ A directory object represents a directory and has the following paths.
   - `type`: String with value of `'dir'`.
   - `data`: 
     - Object with keys as file/directory names that are string encoded in UTF-8.
-    - Values must be links to `file` or `dir` nodes.
+    - Values must be `file` or `dir` nodes.
     - Link *may* resolve to a `hamt` root node.
   - `size`: Integer. Cumulative size of all directories and files in `data`.
 


### PR DESCRIPTION
This changes the specification from being node/block specific to being much more flexible and standardized in terms of "paths." This will allow us to inline any and all values without violating the standard or implementations.