### PR TITLE
Deprecate this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecated
+
+This repository is here for historical purposes only.
+
+Current UnixFSv2 work is happen in the [IPLD specs repository](https://github.com/ipld/specs).
+
 # Discussion: UnixFS Specification
 
 This repo is used to discuss and draft a specification for the next version of UnixFS (the DAG node format used to represent *files and directories* on the IPFS network). You can find and participate in discussion about desired features in [the issues](https://github.com/ipfs/ipld-unixfs/issues) and an [initial specification draft in PR #2](https://github.com/ipfs/ipld-unixfs/pull/2).


### PR DESCRIPTION
Current/active work is happening in the specs repo and not here.